### PR TITLE
Support (inline) string-literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     * [Final Revision](#final-revision) - Idiomatic Go, test-cases, and many new words
   * [BUGS](#bugs)
     * [loops](#loops) - zero expected-iterations actually runs once
+  * [See Also](#see-also)
   * [Github Setup](#github-setup)
 
 
@@ -312,6 +313,21 @@ The handling of loops isn't correct when there should be zero-iterations:
 In our `stars` definition we handle this by explicitly testing the loop
 value before we proceed - At the moment any loop of `0 0` will run once
 so you'll need to add that test if we can't fix this for the general case.
+
+
+
+# See Also
+
+This repository was put together after [experimenting with a scripting language](https://github.com/skx/monkey/), an [evaluation engine](https://github.com/skx/
+evalfilter/), and writing a [BASIC interpreter](https://github.com/skx/gobasic).
+
+I've also played around with a couple of compilers which might be interesting to refer to:
+
+* Brainfuck compiler:
+  * [https://github.com/skx/bfcc/](https://github.com/skx/bfcc/)
+* A math-compiler:
+  * [https://github.com/skx/math-compiler](https://github.com/skx/math-compiler)
+
 
 
 # Github Setup

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ See [foth/](foth/) for the implementation.
 
 ## BUGS
 
-There are two known-issues at the moment:
+A brief list of known-issues:
 
 ### Loops
 

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -85,6 +85,7 @@ func New() *Eval {
 
 	// Populate our built-in functions.
 	e.Dictionary = []Word{
+		Word{Name: "#words", Function: e.wordLen},
 		Word{Name: "*", Function: e.mul},
 		Word{Name: "+", Function: e.add},
 		Word{Name: "-", Function: e.sub},
@@ -98,11 +99,11 @@ func New() *Eval {
 		Word{Name: "==", Function: e.eq},
 		Word{Name: ">", Function: e.gt},
 		Word{Name: ">=", Function: e.gtEq},
-		Word{Name: "dump", Function: e.dump},
 		Word{Name: "debug", Function: e.debugSet},
 		Word{Name: "debug?", Function: e.debugp},
 		Word{Name: "do", Function: e.nop, StartImmediate: true},
 		Word{Name: "drop", Function: e.drop},
+		Word{Name: "dump", Function: e.dump},
 		Word{Name: "dup", Function: e.dup},
 		Word{Name: "else", Function: e.nop},
 		Word{Name: "emit", Function: e.emit},
@@ -113,7 +114,6 @@ func New() *Eval {
 		Word{Name: "swap", Function: e.swap},
 		Word{Name: "then", Function: e.nop, EndImmediate: true},
 		Word{Name: "words", Function: e.words},
-		Word{Name: "#words", Function: e.wordLen},
 	}
 
 	return e

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"foth/lexer"
 	"foth/stack"
 )
 
@@ -118,12 +119,39 @@ func New() *Eval {
 	return e
 }
 
-// Eval processes a list of tokens.
+// Eval evaluates the given expression.
 //
 // This is invoked by our repl with a line of input at the time.
-func (e *Eval) Eval(args []string) error {
+func (e *Eval) Eval(input string) error {
 
-	for _, tok := range args {
+	// Lex our input string into a series of tokens.
+	//
+	// This is done for two reasons:
+	//
+	//  1.  We want to remove comments
+	//
+	//  2.  We support inline strings, such as the following:
+	//
+	//       ." foo bar "
+	//
+	//      Blindly splitting on whitespace would screw those up
+	//
+	l := lexer.New(input)
+	args, err := l.Tokens()
+	if err != nil {
+		return err
+	}
+
+	//
+	// For each token..
+	//
+	for _, token := range args {
+
+		// Get the name of the token.
+		//
+		// The name is the only thing we care about, except
+		// in the case of string-literals
+		tok := token.Name
 
 		// Trim the leading/trailing spaces,
 		// and skip any empty tokens
@@ -131,7 +159,6 @@ func (e *Eval) Eval(args []string) error {
 		if tok == "" {
 			continue
 		}
-
 		// Are we in compiling mode?
 		if e.compiling || (e.immediate > 0) {
 

--- a/foth/eval/eval_test.go
+++ b/foth/eval/eval_test.go
@@ -9,6 +9,7 @@ import (
 func TestBasic(t *testing.T) {
 
 	e := New()
+	e.debug = true
 	out := e.Eval("  . ")
 
 	if out == nil {
@@ -25,19 +26,22 @@ func TestDumpWords(t *testing.T) {
 	if e.debug != true {
 		t.Fatalf("putenv didn't enable debugging")
 	}
-	os.Setenv("DEBUG", "")
 
 	// test definitions
 	tests := []string{": star 42 emit ;",
 		": stars 0 do star loop 10 emit ;",
 		": test_hot  0 > if star then star ;",
-		": tests 0 0 = if 1 else 2 then ;"}
+		": tests 0 0 = if 1 else 2 then ;",
+		": tests 0 0 = if .\" test \" else .\" ok\" ;",
+		"0 0 = if .\" test \" else .\" ok\"",
+	}
 
 	for _, str := range tests {
 		e.Eval(str)
 	}
 
 	e.dumpWord(0)
+	os.Setenv("DEBUG", "")
 }
 
 // Try running one of each of our test-cases
@@ -45,6 +49,7 @@ func TestEvalWord(t *testing.T) {
 
 	// dummy test
 	e := New()
+	e.debug = true
 
 	// test definitions
 	tests := []string{": star 42 emit ;",
@@ -71,6 +76,7 @@ func TestFloatFail(t *testing.T) {
 
 	for _, str := range tests {
 		e := New()
+		e.debug = true
 		err := e.Eval(str)
 		if err == nil {
 			t.Fatalf("expected error processing '%s', got none", str)
@@ -90,7 +96,9 @@ func TestIfThenElse(t *testing.T) {
 
 	tests := []Test{
 		Test{input: "3 3 = if 1 then", result: 1},
+		Test{input: "3 3 = if .\" ok \" 1 then", result: 1},
 		Test{input: ": f 3 3 = if 1 then ; f", result: 1},
+		Test{input: ": f 3 3 = if .\" ok \" 1 then ; f", result: 1},
 
 		Test{input: "3 3 = invert if 1 else 2 then", result: 2},
 		Test{input: ": f 3 3 = invert if 1 else 2 then ; f", result: 2},
@@ -108,6 +116,7 @@ func TestIfThenElse(t *testing.T) {
 	for _, test := range tests {
 
 		e := New()
+		e.debug = true
 		err := e.Eval(test.input)
 		if err != nil {
 			t.Fatalf("unexpected error processing '%s': %s", test.input, err.Error())

--- a/foth/eval/eval_test.go
+++ b/foth/eval/eval_test.go
@@ -9,7 +9,7 @@ import (
 func TestBasic(t *testing.T) {
 
 	e := New()
-	out := e.Eval([]string{"", ".", " "})
+	out := e.Eval("  . ")
 
 	if out == nil {
 		t.Fatalf("expected error, got none")
@@ -34,7 +34,7 @@ func TestDumpWords(t *testing.T) {
 		": tests 0 0 = if 1 else 2 then ;"}
 
 	for _, str := range tests {
-		e.Eval(strings.Split(str, " "))
+		e.Eval(str)
 	}
 
 	e.dumpWord(0)
@@ -59,7 +59,7 @@ func TestEvalWord(t *testing.T) {
 		"-1 test_hot"}
 
 	for _, str := range tests {
-		e.Eval(strings.Split(str, " "))
+		e.Eval(str)
 	}
 
 }
@@ -71,7 +71,7 @@ func TestFloatFail(t *testing.T) {
 
 	for _, str := range tests {
 		e := New()
-		err := e.Eval(strings.Split(str, " "))
+		err := e.Eval(str)
 		if err == nil {
 			t.Fatalf("expected error processing '%s', got none", str)
 		}
@@ -108,7 +108,7 @@ func TestIfThenElse(t *testing.T) {
 	for _, test := range tests {
 
 		e := New()
-		err := e.Eval(strings.Split(test.input, " "))
+		err := e.Eval(test.input)
 		if err != nil {
 			t.Fatalf("unexpected error processing '%s': %s", test.input, err.Error())
 		}

--- a/foth/foth.4th
+++ b/foth/foth.4th
@@ -29,7 +29,16 @@
 # We add a test here to make sure that the user enters > 0
 # as their argument
 #
-: stars dup 0 > if 0 do star loop else drop then cr ;
+: stars dup 0 > if 0 do star loop else drop then ;
+
+#
+# Squares: Draw a box
+#
+#          e.g. 10 squares
+#
+: squares 0 do
+   over stars cr
+  loop ;
 
 
 #
@@ -42,15 +51,17 @@
 #
 : cube dup square * ;
 
+
 #
 # 1+: add one to a number
 #
 : 1+ 1 + ;
 
+
 #
 # boot: output a message on-startup
 #
-: bootup 87 emit 101 emit 108 emit 99 emit 111 emit 109 emit 101 emit 32 emit 116 emit 111 emit 32 emit 102 emit 111 emit 116 emit 104 emit 33 emit 10 emit ;
+: bootup ." Welcome to foth!\n " ;
 bootup
 
 
@@ -64,15 +75,13 @@ bootup
 # added this example.
 #
 
-# output "Hot"
-: hot 72 emit 111 emit 116 emit 10 emit ;
+# output a hot/cold message
+: hot  ." Hot\n  " ;
+: cold ." Cold\n " ;
 
-# Output "Cold"
-: cold 67 emit 111 emit 108 emit 100 emit 10 emit ;
-
-: test_hot  0 > if hot then ;
+: test_hot   0 >  if hot then ;
 : test_cold  0 <= if cold then ;
-: temp dup test_hot test_cold ;
+: temp? dup test_hot test_cold ;
 
 
 #
@@ -86,8 +95,11 @@ bootup
 # Output "NOT frozen\n"
 : non_frozen 78 emit 79 emit 84 emit 32 emit 102 emit 114 emit 111 emit 122 emit  101 emit 110 emit 10 emit ;
 
-# Output one or othre of the messages?
+# Output one or other of the messages?
 : frozen? 0 <= if frozen else non_frozen then cr ;
+
+# All in one.
+: frozen2? 0 <= if ." frozen " else ." not frozen " then cr ;
 
 
 #

--- a/foth/lexer/lexer.go
+++ b/foth/lexer/lexer.go
@@ -1,0 +1,113 @@
+// Package lexer parses a string as FORTH
+package lexer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Token is a single token.
+//
+// All our tokens have a name, only string-literals have a value which
+// is used for anything.
+type Token struct {
+
+	// Name holds the name of the token.
+	Name string
+
+	// For the case of a string-literal we store the value here.
+	Value string
+}
+
+// Lexer holds our state.
+type Lexer struct {
+
+	// input is the string we were given
+	input string
+}
+
+// New creates a new lexer which allows parsing a string of FORTH tokens
+// into an array of tokens that can be interpreted.
+func New(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// Tokens returns all the tokens from the given input-string.
+func (l *Lexer) Tokens() ([]Token, error) {
+
+	var res []Token
+
+	// We walk the input from start to finish
+	offset := 0
+
+	// Value of the current token - built up character by character.
+	cur := ""
+
+	for offset < len(l.input) {
+
+		c := l.input[offset]
+		switch string(c) {
+
+		case " ", "\n", "\r", "\t":
+
+			// If we've built up a word then we save it away.
+			if len(cur) != 0 {
+				res = append(res, Token{Name: cur})
+				cur = ""
+			}
+
+		case ".":
+
+			// ensure we don't walk off the array
+			if offset+1 < len(l.input) {
+
+				// next character is a string?
+				if l.input[offset+1] == '"' {
+
+					// skip the "."
+					offset++
+
+					// skip the opening """
+					offset++
+
+					// We're now inside the string
+					closed := false
+					val := ""
+					for offset < len(l.input) {
+						if l.input[offset] == '"' {
+							closed = true
+							break
+						} else {
+							val += string(l.input[offset])
+						}
+						offset++
+					}
+
+					// Failed to close the string?
+					if !closed {
+						return res, fmt.Errorf("unterminated string")
+					}
+
+					// Otherwise save it away
+					val = strings.TrimSpace(val)
+					res = append(res, Token{Name: ".\"", Value: val})
+				} else {
+					cur = cur + "."
+				}
+			} else {
+				cur = cur + "."
+			}
+		default:
+			cur = cur + string(c)
+		}
+		offset++
+	}
+
+	// end token?
+	if cur != "" {
+		res = append(res, Token{Name: cur})
+	}
+
+	// All done.
+	return res, nil
+}

--- a/foth/lexer/lexer.go
+++ b/foth/lexer/lexer.go
@@ -56,6 +56,39 @@ func (l *Lexer) Tokens() ([]Token, error) {
 				cur = ""
 			}
 
+		case "\\":
+			// Comment to the end of the line
+			for offset < len(l.input) {
+				if l.input[offset] == '\n' {
+					break
+				}
+				offset++
+			}
+
+		case "(":
+
+			// skip the "("
+			offset++
+
+			// Eat the comment - which is everything
+			// between the "(" and ")" (inclusive)
+			//
+			// NOTE: Nested comments are prohibited
+			closed := false
+			for offset < len(l.input) {
+				if l.input[offset] == ')' {
+					closed = true
+					break
+				}
+				if l.input[offset] == '(' {
+					return res, fmt.Errorf("nested comments are illegal")
+				}
+				offset++
+			}
+			if !closed {
+				return res, fmt.Errorf("unterminated comment")
+			}
+
 		case ".":
 
 			// ensure we don't walk off the array

--- a/foth/lexer/lexer_test.go
+++ b/foth/lexer/lexer_test.go
@@ -1,0 +1,77 @@
+package lexer
+
+import (
+	"strings"
+	"testing"
+)
+
+// Empty input should give empty output
+func TestEmpty(t *testing.T) {
+	l := New(" \t \r \n")
+	out, err := l.Tokens()
+	if err != nil {
+		t.Fatalf("error lexing")
+	}
+
+	if len(out) != 0 {
+		t.Fatalf("Unexpected output, got: %v", out)
+	}
+
+}
+
+func TestString(t *testing.T) {
+
+	l := New("start .\" foo bar baz \" end")
+	out, err := l.Tokens()
+
+	if err != nil {
+		t.Fatalf("error lexing")
+	}
+
+	if out[0].Name != "start" {
+		t.Fatalf("got bad prefix")
+	}
+	if out[1].Name != ".\"" {
+		t.Fatalf("got bad string")
+	}
+	if out[1].Value != "foo bar baz" {
+		t.Fatalf("got bad string: '%s'", out[1].Value)
+	}
+	if out[2].Name != "end" {
+		t.Fatalf("got bad suffix")
+	}
+
+}
+
+// Unterminated strings are a bug
+func TestStringUnterminated(t *testing.T) {
+
+	l := New("  .\" string here ")
+
+	_, err := l.Tokens()
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "unterminated string") {
+		t.Fatalf("got an error, but the wrong one")
+	}
+}
+
+// Not strings
+func TestNotString(t *testing.T) {
+
+	l := New("  .-  .")
+
+	out, err := l.Tokens()
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	if out[0].Name != ".-" {
+		t.Fatalf("got bad prefix")
+	}
+	if out[1].Name != "." {
+		t.Fatalf("got bad suffix")
+	}
+
+}

--- a/foth/lexer/lexer_test.go
+++ b/foth/lexer/lexer_test.go
@@ -5,6 +5,56 @@ import (
 	"testing"
 )
 
+// Comments should be reoved
+func TestComment(t *testing.T) {
+
+	l := New(` to \ This is a comment
+( comment here )fo
+`)
+
+	out, err := l.Tokens()
+	if err != nil {
+		t.Fatalf("error lexing: %s", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("Unexpected output, got: %v", out)
+	}
+	if out[0].Name != "to" {
+		t.Fatalf("got bad prefix")
+	}
+	if out[1].Name != "fo" {
+		t.Fatalf("got bad suffix")
+	}
+}
+
+// Nested comments are a bug
+func TestCommentNested(t *testing.T) {
+
+	l := New("  ( comment ( here ) ) ")
+
+	_, err := l.Tokens()
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "nested comments") {
+		t.Fatalf("got an error, but the wrong one")
+	}
+}
+
+// Unterminated comments are a bug
+func TestCommentUnterminated(t *testing.T) {
+
+	l := New("  ( comment here ")
+
+	_, err := l.Tokens()
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "unterminated comment") {
+		t.Fatalf("got an error, but the wrong one")
+	}
+}
+
 // Empty input should give empty output
 func TestEmpty(t *testing.T) {
 	l := New(" \t \r \n")

--- a/foth/main.go
+++ b/foth/main.go
@@ -41,7 +41,7 @@ func doInit(eval *eval.Eval, path string) error {
 		if !strings.HasPrefix(line, "#") {
 
 			// Evaluate
-			err := eval.Eval(strings.Split(line, " "))
+			err := eval.Eval(line)
 			if err != nil {
 				fmt.Printf("ERROR: %s\n", err.Error())
 			}
@@ -103,7 +103,7 @@ func main() {
 		// Trim it
 		text = strings.TrimSpace(text)
 
-		err = forth.Eval(strings.Split(text, " "))
+		err = forth.Eval(text)
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())
 		}


### PR DESCRIPTION
We currently have this:

```
: cold 67 emit 111 emit 108 emit 100 emit 10 emit ;
```

We should have:

```
: cold ." Cold " ;
```

This pull-request will allow that, by implementing support for string-literals - either in compiled words, or via the REPL.

* Use a tokenizer to parse input
  * Because clearly splitting on whitespace will fuck this up.
* Update our signatures to use a string, rather than array of strings.

This will close #5.