### PR TITLE
Allow redirecting output.

### DIFF
--- a/foth/eval/builtins.go
+++ b/foth/eval/builtins.go
@@ -93,7 +93,7 @@ func (e *Eval) emit() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%c", rune(a))
+	e.printString(string(rune(a)))
 	return nil
 }
 
@@ -219,7 +219,7 @@ func (e *Eval) print() error {
 	// If the value on the top of the stack is an integer
 	// then show it as one - i.e. without any ".00000".
 	if float64(int(a)) == a {
-		fmt.Printf("%d\n", int(a))
+		e.printString(fmt.Sprintf("%d\n", int(a)))
 		return nil
 	}
 
@@ -234,7 +234,7 @@ func (e *Eval) print() error {
 	for strings.HasSuffix(output, "0") {
 		output = strings.TrimSuffix(output, "0")
 	}
-	fmt.Printf("%s\n", output)
+	e.printString(fmt.Sprintf("%s\n", output))
 	return nil
 }
 

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -2,6 +2,7 @@
 package eval
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
@@ -56,6 +57,9 @@ type Eval struct {
 
 	// Dictionary entries
 	Dictionary []Word
+
+	// STDOUT is the writer used for `.`, `print`, and `emit` words
+	STDOUT *bufio.Writer
 
 	// Private details
 
@@ -310,6 +314,15 @@ func (e *Eval) SetVariable(name string, value float64) {
 	}
 
 	e.vars = append(e.vars, Variable{Name: name, Value: value})
+}
+
+// SetWriter allows you to setup a special writer for all STDOUT
+// messages this application will produce.
+//
+// i.e. Writes from `.`, `emit`, `print`, and string-immediates will
+// go there.
+func (e *Eval) SetWriter(writer *bufio.Writer) {
+	e.STDOUT = writer
 }
 
 // compileToken is called with a new token, when we're in compiling-mode.
@@ -803,5 +816,11 @@ func (e *Eval) printString(str string) {
 	str = strings.ReplaceAll(str, "\\n", "\n")
 	str = strings.ReplaceAll(str, "\\t", "\t")
 	str = strings.ReplaceAll(str, "\\r", "\r")
-	fmt.Printf("%s", str)
+
+	if e.STDOUT == nil {
+		e.STDOUT = bufio.NewWriter(os.Stdout)
+	}
+
+	e.STDOUT.WriteString(str)
+	e.STDOUT.Flush()
 }


### PR DESCRIPTION
Close #7, by allowing users to setup an explicit output-stream.

All our primitives that write output use a level of indirection, to allow moving it elsewhere.