### PR TITLE
Loops

### DIFF
--- a/foth/eval/builtins.go
+++ b/foth/eval/builtins.go
@@ -142,6 +142,15 @@ func (e *Eval) gtEq() error {
 	})()
 }
 
+func (e *Eval) i() error {
+	if len(e.loops) > 0 {
+		i := e.loops[len(e.loops)-1].Current
+		e.Stack.Push(float64(i))
+		return nil
+	}
+	return fmt.Errorf("you cannot access 'i' outside a loop-body")
+}
+
 func (e *Eval) invert() error {
 	v, err := e.Stack.Pop()
 	if err != nil {
@@ -194,6 +203,16 @@ func (e *Eval) min() error {
 		}
 		return n
 	})()
+}
+
+func (e *Eval) m() error {
+	if len(e.loops) > 0 {
+		m := e.loops[len(e.loops)-1].Max
+		e.Stack.Push(float64(m))
+		return nil
+	}
+
+	return fmt.Errorf("you cannot access 'm' outside a loop-body")
 }
 
 func (e *Eval) mul() error {

--- a/foth/eval/builtins.go
+++ b/foth/eval/builtins.go
@@ -157,22 +157,6 @@ func (e *Eval) invert() error {
 }
 
 func (e *Eval) loop() error {
-	var cur, max float64
-	var err error
-	cur, err = e.Stack.Pop()
-	if err != nil {
-		return err
-	}
-	max, err = e.Stack.Pop()
-	if err != nil {
-		return err
-	}
-
-	cur++
-
-	e.Stack.Push(max)
-	e.Stack.Push(cur)
-
 	return nil
 }
 

--- a/foth/eval/builtins_test.go
+++ b/foth/eval/builtins_test.go
@@ -424,43 +424,6 @@ func TestInvert(t *testing.T) {
 
 }
 
-func TestLoop(t *testing.T) {
-
-	e := New()
-
-	// empty stack
-	err := e.loop()
-	if err == nil {
-		t.Fatalf("expected error with empty stack")
-	}
-
-	e.Stack.Push(10)
-	e.loop()
-	if err == nil {
-		t.Fatalf("expected error with empty stack")
-	}
-
-	// Two values
-	e.Stack.Push(4)
-	e.Stack.Push(54)
-
-	e.loop()
-	a, err := e.Stack.Pop()
-	if a != 55 {
-		t.Fatalf("unexpected result, got %f", a)
-	}
-	if err != nil {
-		t.Fatalf("unexpected error")
-	}
-	b, err2 := e.Stack.Pop()
-	if b != 4 {
-		t.Fatalf("unexpected result, got %f", b)
-	}
-	if err2 != nil {
-		t.Fatalf("unexpected error")
-	}
-}
-
 func TestLt(t *testing.T) {
 
 	e := New()

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -677,6 +677,7 @@ func (e *Eval) dumpWord(idx int) {
 			off++
 		} else if v == -11 {
 			codes = append(codes, fmt.Sprintf("%d: [loop-test]", off))
+			off++
 		} else {
 			codes = append(codes, fmt.Sprintf("%d: %s", off, e.Dictionary[int(v)].Name))
 		}

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -12,6 +12,18 @@ import (
 	"foth/stack"
 )
 
+// Loop holds the state of a running do/while loop.
+type Loop struct {
+	// Start is the starting number our loop begins from.
+	Start int
+
+	// Max holds the terminating number our loop finishes at.
+	Max int
+
+	// Current holds the current number of the iteration.
+	Current int
+}
+
 // Variable is the structure for storing variable names, and contents
 type Variable struct {
 	// Name is the name of the variable
@@ -49,7 +61,10 @@ type Word struct {
 	EndImmediate bool
 }
 
-// Eval is our evaluation structure
+// Eval is our evaluation structure, which holds state of where
+// we're executing code from.
+//
+// The state includes the variables, inline-strings, etc.
 type Eval struct {
 
 	// Stack holds our operands.
@@ -66,6 +81,13 @@ type Eval struct {
 	// Literal strings.  As encountered in our program.
 	strings []string
 
+	// Have we already bumped our immediate-count?
+	//
+	// This is a gross-hack to account for the fact that
+	// compileToken needs to bump the immediate-count when
+	// it sees a nested do, or similar token.
+	bumped bool
+
 	// Are we in a compiling mode?
 	compiling bool
 
@@ -78,8 +100,9 @@ type Eval struct {
 	// Temporary word we're compiling
 	tmp Word
 
-	// open of the last do
-	doOpen int
+	// We keep a stack of the last time we saw a `do` token,
+	// so we can pair it with the appropriate matching `loop`.
+	doOpen []int
 
 	// When we generate IF-statements we have to patch one or two
 	// offsets, depending on whether there is an ELSE branch present
@@ -88,6 +111,12 @@ type Eval struct {
 	// Here we keep track of them
 	ifOffset1 int
 	ifOffset2 int
+
+	// Loops stores loops which are currently open.
+	//
+	// When we compile `do` we add a new one, when the `loop`
+	// word is completed we remove one.
+	loops []Loop
 
 	// Variables
 	vars []Variable
@@ -240,6 +269,7 @@ func (e *Eval) Eval(input string) error {
 			// Are we starting immediate mode?
 			if !e.compiling && e.Dictionary[idx].StartImmediate {
 				e.immediate++
+				e.bumped = true
 
 				// Errors here can't happen.
 				//
@@ -310,7 +340,8 @@ func (e *Eval) Reset() {
 	e.tmp.Words = []float64{}
 
 	// we're not in a do/loop
-	e.doOpen = 0
+	e.doOpen = []int{}
+	e.loops = []Loop{}
 
 	// we're not in a conditional
 	e.ifOffset1 = 0
@@ -409,6 +440,26 @@ func (e *Eval) compileToken(token lexer.Token) error {
 	idx := e.findWord(tok)
 	if idx >= 0 {
 
+		//
+		// We have to do some juggling here because
+		// when we find a word with `EndImmediate` we
+		// terminate.
+		//
+		// So we have to make sure we don't terminate
+		// early if something else opened.
+		//
+		// i.e. "loop" would usually terminate immediate-mode,
+		// but we can't stop there for definitions that use
+		// nested loops
+		//
+		if imm && e.Dictionary[idx].StartImmediate {
+			if e.bumped {
+				e.immediate--
+				e.bumped = false
+			}
+			e.immediate++
+		}
+
 		// Found the word, add to the end.
 		e.tmp.Words = append(e.tmp.Words, float64(idx))
 
@@ -420,15 +471,33 @@ func (e *Eval) compileToken(token lexer.Token) error {
 
 		// If the word was a "DO"
 		if tok == "do" {
-			e.doOpen = len(e.tmp.Words) - 1
+
+			// keep track of where we are
+			e.doOpen = append(e.doOpen, len(e.tmp.Words)-1)
+
+			// we compile this into a "new-loop" instruction
+			e.tmp.Words = append(e.tmp.Words, -10)
+			e.tmp.Words = append(e.tmp.Words, 99) // dull
 		}
 
 		// if the word was a "LOOP"
 		if tok == "loop" {
 
-			// offset of do must be present
-			e.tmp.Words = append(e.tmp.Words, -2)
-			e.tmp.Words = append(e.tmp.Words, float64(e.doOpen))
+			// We load the loop, increment, etc.
+			e.tmp.Words = append(e.tmp.Words, -11)
+			e.tmp.Words = append(e.tmp.Words, 99) // dull
+
+			// We've bumped the instance, and pushed
+			// a result onto the stack now.
+			//
+			// So we jump back to repeat if we must.
+			e.tmp.Words = append(e.tmp.Words, -3)
+			e.tmp.Words = append(e.tmp.Words, float64(e.doOpen[len(e.doOpen)-1]+3))
+
+			// We've matched the do-loop pair - drop the
+			// open-reference
+			e.doOpen = e.doOpen[:len(e.doOpen)-1]
+
 		}
 
 		// output a string, in compiled form
@@ -592,9 +661,6 @@ func (e *Eval) dumpWord(idx int) {
 		if v == -1 {
 			codes = append(codes, fmt.Sprintf("%d: store %f", off, word.Words[off+1]))
 			off++
-		} else if v == -2 {
-			codes = append(codes, fmt.Sprintf("%d: [loop-jmp %f]", off, word.Words[off+1]))
-			off++
 		} else if v == -3 {
 			codes = append(codes, fmt.Sprintf("%d: [cond-jmp %f]", off, word.Words[off+1]))
 			off++
@@ -604,6 +670,11 @@ func (e *Eval) dumpWord(idx int) {
 		} else if v == -5 {
 			codes = append(codes, fmt.Sprintf("%d: [print-string %f (\"%s\")]", off, word.Words[off+1], e.strings[int(word.Words[off+1])]))
 			off++
+		} else if v == -10 {
+			codes = append(codes, fmt.Sprintf("%d: [new-loop]", off))
+			off++
+		} else if v == -11 {
+			codes = append(codes, fmt.Sprintf("%d: [loop-test]", off))
 		} else {
 			codes = append(codes, fmt.Sprintf("%d: %s", off, e.Dictionary[int(v)].Name))
 		}
@@ -635,8 +706,6 @@ func (e *Eval) dumpWord(idx int) {
 //
 //    "-1" means the next value is a number
 //
-//    "-2" is an loop jump, which will change our IP.
-//
 //    "-3" is a conditional-jump, which will change our IP if
 //         the topmost item on the stack is "0".
 //
@@ -644,6 +713,12 @@ func (e *Eval) dumpWord(idx int) {
 //
 //    "-5" prints a string, stored in our literal-area.
 //         Dynamic strings are not supported.
+//
+//    "-10" creates a new Loop structure.
+//          (i.e. `do`).
+//
+//    "-11" handles the test/termination of a loop condition.
+//          (i.e. `loop`).
 //
 func (e *Eval) evalWord(index int) error {
 
@@ -704,35 +779,7 @@ func (e *Eval) evalWord(index int) error {
 			// print a string
 			e.printString(e.strings[int(opcode)])
 			state = "default"
-		} else if state == "loop-jump" {
 
-			// If the two top-most entries
-			// are not equal, then jump
-			//
-			// TODO: This is horrid
-			cur, ee := e.Stack.Pop()
-			if ee != nil {
-				return ee
-			}
-			max, eee := e.Stack.Pop()
-			if eee != nil {
-				return eee
-			}
-
-			if max > cur {
-				// put them back
-				e.Stack.Push(max)
-				e.Stack.Push(cur)
-
-				// change opcode
-				ip = int(opcode)
-
-				// decrement as it'll get bumped at
-				// the foot of the loop
-				ip--
-			}
-
-			state = "default"
 		} else if state == "cond-jump" {
 			// Jump only if 0 is on the top of the stack.
 			//
@@ -758,6 +805,50 @@ func (e *Eval) evalWord(index int) error {
 				}
 			}
 			state = "default"
+		} else if state == "new-loop" {
+
+			// given the two-values on the stack
+			// create and save a new Loop structure
+			// to describe this loop.
+			cur, err := e.Stack.Pop()
+			if err != nil {
+				return err
+			}
+
+			max, err2 := e.Stack.Pop()
+			if err2 != nil {
+				return err2
+			}
+
+			// new loop
+			l := Loop{
+				Start:   int(cur),
+				Max:     int(max),
+				Current: int(cur),
+			}
+
+			// save it away
+			e.loops = append(e.loops, l)
+			state = "default"
+		} else if state == "loop-test" {
+
+			// we've working with the last loop
+			l := len(e.loops) - 1
+
+			// bump the count
+			e.loops[l].Current++
+
+			// test to see if the loop is over
+			if e.loops[l].Current >= e.loops[l].Max {
+				e.Stack.Push(1)
+
+				// loop is over now
+				e.loops = e.loops[:len(e.loops)-1]
+			} else {
+				e.Stack.Push(0)
+			}
+
+			state = "default"
 		} else if state == "jump" {
 
 			// change opcode
@@ -768,18 +859,19 @@ func (e *Eval) evalWord(index int) error {
 			state = "default"
 		} else if state == "default" {
 
-			// if we see -1 we're adding a number
 			switch opcode {
 			case -1:
 				state = "add-number"
-			case -2:
-				state = "loop-jump"
 			case -3:
 				state = "cond-jump"
 			case -4:
 				state = "jump"
 			case -5:
 				state = "string-print"
+			case -10:
+				state = "new-loop"
+			case -11:
+				state = "loop-test"
 			default:
 				err := e.evalWord(int(opcode))
 				if err != nil {

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -163,7 +163,9 @@ func New() *Eval {
 
 		// loop-handling
 		Word{Name: "do", Function: e.nop, StartImmediate: true},
+		Word{Name: "i", Function: e.i},
 		Word{Name: "loop", Function: e.loop, EndImmediate: true},
+		Word{Name: "m", Function: e.m},
 
 		// mathematical
 		Word{Name: "*", Function: e.mul},

--- a/foth/eval/eval_test.go
+++ b/foth/eval/eval_test.go
@@ -32,6 +32,41 @@ func TestBasic(t *testing.T) {
 	}
 }
 
+func TestClearWords(t *testing.T) {
+
+	// create instance
+	e := New()
+	e.debug = true
+
+	// Push some stuff
+	err := e.Eval("1 3 4 5")
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	// Ensure it is non-empty
+	if e.Stack.IsEmpty() {
+		t.Fatalf("unexpected stack")
+	}
+	if e.Stack.Len() != 4 {
+		t.Fatalf("unexpected stack")
+	}
+
+	// Clear the stack
+	err = e.Eval(".s clearstack")
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	// Ensure it is non-empty
+	if !e.Stack.IsEmpty() {
+		t.Fatalf("unexpected stack")
+	}
+	if e.Stack.Len() != 0 {
+		t.Fatalf("unexpected stack")
+	}
+
+}
 func TestDumpWords(t *testing.T) {
 
 	// dummy test

--- a/foth/eval/eval_test.go
+++ b/foth/eval/eval_test.go
@@ -219,6 +219,73 @@ func TestIfThenElse(t *testing.T) {
 	}
 }
 
+func TestMaxMin(t *testing.T) {
+
+	errors := []string{
+		// no entry
+		"max",
+		"min",
+
+		// one too few
+		"3 max",
+		"3 min"}
+
+	for _, txt := range errors {
+
+		// create instance
+		e := New()
+		e.debug = true
+
+		err := e.Eval(txt)
+		if err == nil {
+			t.Fatalf("expected an error, got none")
+		}
+		if !strings.Contains(err.Error(), "underflow") {
+			t.Fatalf("found wrong error: %s", err.Error())
+		}
+	}
+
+	type TestCase struct {
+		Input  string
+		Result float64
+	}
+
+	tests := []TestCase{
+		{Input: "3 4 max", Result: 4},
+		{Input: "4 3 max", Result: 4},
+		{Input: "3 3 max", Result: 3},
+		{Input: "-4 -30 max", Result: -4},
+
+		{Input: "3 4 min", Result: 3},
+		{Input: "4 3 min", Result: 3},
+		{Input: "2 2 min", Result: 2},
+		{Input: "-4 -30 min", Result: -30},
+	}
+
+	for _, test := range tests {
+
+		// create instance
+		e := New()
+		e.debug = true
+
+		err := e.Eval(test.Input)
+		if err != nil {
+			t.Fatalf("unexpected error")
+		}
+
+		ret, err2 := e.Stack.Pop()
+		if err2 != nil {
+			t.Fatalf("failed to get stack value")
+		}
+		if !e.Stack.IsEmpty() {
+			t.Fatalf("expected stack to be empty, it wasn't")
+		}
+		if ret != test.Result {
+			t.Fatalf("unexpected result for %s -> %f", test.Input, ret)
+		}
+	}
+}
+
 func TestReset(t *testing.T) {
 
 	// create instance

--- a/foth/foth.4th
+++ b/foth/foth.4th
@@ -13,9 +13,6 @@
 \
 \        ( comment ( comment again ) )
 \
-\        This is only supported here because we process single-line
-\        comments before the other kind of comments.
-
 
 \
 \ Declare a variable named `PI`
@@ -68,6 +65,23 @@ variable val
 
 
 \
+\ bell: make some noise
+\
+: bell 7 emit ;
+
+\
+\ Delay seems necessary to make bells
+\
+: bells
+    3 0 do
+        bell
+        3000000 0 do
+            nop
+        loop
+    loop
+;
+
+\
 \ We define `=` (and `==`) by default, but we do not have a built-in
 \ function for not-equals.  We can fix that now:
 \
@@ -108,9 +122,18 @@ variable val
 : stars dup 0 > if 0 do star loop else drop then ;
 
 \
-\ Squares: Draw a box
+\ Squares: Draw a square of stars
 \
 \          e.g. 10 squares
+\
+\ Here we define a loop that runs from N to 0, and we use "m" as
+\ the maximum-value of the loop.
+\
+\ Inside loop-bodies we can access two variables like that:
+\
+\    i  -> The current value of the loop
+\
+\    m  -> The maximum value of the loop (which will terminate it).
 \
 : squares 0 do
    over stars cr
@@ -140,14 +163,13 @@ variable val
 : bootup ." Welcome to foth!\n " ;
 bootup
 
-
 \
 \ IF test
 \
 \ This section of the startup-file outputs either "hot" or "cold" depending
 \ on whether a number is <0 or not.
 \
-\ Here we repeat our work because we don't have support for ELSE when we
+\ Here we repeat our work because we did't have support for ELSE when we
 \ added this example.
 \
 
@@ -166,16 +188,19 @@ bootup
 \
 
 \ Output "frozen\n"
-: frozen 102 emit 114 emit 111 emit 122 emit 101 emit 110 emit 10 emit ;
+: frozen ." frozen\n " ;
 
 \ Output "NOT frozen\n"
-: non_frozen 78 emit 79 emit 84 emit 32 emit 102 emit 114 emit 111 emit 122 emit  101 emit 110 emit 10 emit ;
+: non_frozen ." NOT frozen\n " ;
 
-\ Output one or other of the messages?
+\ Output the appropiate message.
 : frozen? 0 <= if frozen else non_frozen then cr ;
 
-\ All in one.
-: frozen2? 0 <= if ." frozen " else ." not frozen " then cr ;
+\
+\ Or we could have written the following word to do everything
+\ in one-step:
+\
+: frozen2? 0 <= if ." frozen " else ." NOT frozen " then cr ;
 
 
 \


### PR DESCRIPTION
This pull-request, after several false-starts, will close #10 by allowing nested loops:

* Either immediately.
* Or in compiled form.

The specific problem I was butting my head against is the fact that when we see a `do` token we have the stack-setup - so the temptation is to use it there, and nest it that way.

However all the _real_ magic  of `do`/`loop` comes in the compiled version.  When the stack is not useful.

So we emit a pair of bytecode-operations:

* Create a new Loop{} structure, from the stack.
* Test/Drop it.

That resolves all my problems.  I think.