### PR TITLE
16 recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The end-result of this work is a simple scripting-language which you could easil
   * If no arguments are supplied run a simple REPL instead.
 * A standard library is loaded, from the present directory, if it is present.
   * See what we load by default in [foth/foth.4th](foth/foth.4th).
+* The use of recursive definitions, for example:
+  * `: factorial recursive  dup 1 >  if  dup 1 -  factorial *  then  ;`
 
 
 ## Installation
@@ -403,6 +405,8 @@ The final version, stored beneath [foth/](foth/), is pretty similar to the previ
 * It is now possible to redefine existing words.
 * Execute any files specified on the command line.
   * If no files are specified run the REPL.
+* We've added support for recursive definitions, in #16 for example allowing:
+  * `: factorial recursive  dup 1 >  if  dup 1 -  factorial *  then  ;`
 
 See [foth/](foth/) for the implementation.
 


### PR DESCRIPTION
Allow recursive definitions.
    
This pull request is a little magical, and allows the use of recursive definitions.
    
Typically when we create a new word/definition we essentially build up some "bytecode" which might allow several things:
    
* The lookup and reference of an existing word being stored.
* Some special pseudo operations, prefixed with negative values.
  * Jumps
  * Inline integers
    
Compiling a word which contains references to unknown words fails, because their "address", or "offset" cannot be found.  Which means this fails:
    
            : factorial dup 1 >  if  dup 1 -  factorial *  then  ;
    
The compilation will encode "dupe", "1", ">", etc, but will then fail to find the word "factorial" towards the end - that word doesn't exist, because the definition is not complete until we hit ";".
    
This pull-request makes an assumption; if a definition is _recursive_ then the call to any unknown word will be a call to "itself", and thus will be the final word in our known set of words.
    
i.e. When compiling a recursive word we calculate the word's offset which will be compiled, and use it.  This allows:
    
            : factorial recursive  dup 1 >  if  dup 1 -  factorial *  then  ;
    
And this closes #16.

