### PR TITLE
Added part7 - with basic string-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@
     * [Part 4](#part-4) - Allow defining improved words via the REPL.
     * [Part 5](#part-5) - Allow executing loops via `do`/`loop`.
     * [Part 6](#part-6) - Allow conditional execution via `if`/`then`.
+    * [Part 7](#part-7) - Added minimal support for strings.
     * [Final Revision](#final-revision) - Idiomatic Go, test-cases, and many new words
   * [BUGS](#bugs)
     * [loops](#loops) - zero expected-iterations actually runs once
   * [See Also](#see-also)
   * [Github Setup](#github-setup)
+
+
 
 
 # foth
@@ -69,6 +72,7 @@ The end-result of this work is a simple scripting-language which you could easil
   * `: factorial recursive  dup 1 >  if  dup 1 -  factorial *  then  ;`
 
 
+
 ## Installation
 
 You can find binary releases of the final-version upon the [project release page](https://github.com/skx/foth/releases), but if you prefer you can install from source easily.
@@ -89,6 +93,7 @@ go build .
 ```
 
 The executable will try to load [foth.4th](foth/foth.4th) from the current-directory, so you'll want to fetch that too.  But otherwise it should work as you'd expect - the startup-file defines several useful words, so running without it is a little annoying but it isn't impossible.
+
 
 
 ## Embedded Usage
@@ -114,6 +119,7 @@ Basically we ignore the common FORTH-approach of using a return-stack, and imple
 * So we implement `if` or `do`/`loop` in a hard-coded fashion.
   * That means we can't allow a user to define `while`, or similar.
   * But otherwise our language is flexible enough to allow _real_ work to be done with it.
+
 
 
 ## Implementation Approach
@@ -174,7 +180,6 @@ with the ability to print the top-most entry of the stack:
 See [part1/](part1/) for details.
 
 
-
 ### Part 2
 
 Part two allows the definition of new words in terms of existing ones,
@@ -196,7 +201,6 @@ squares the number at the top of the stack.
      ^D
 
 See [part2/](part2/) for details.
-
 
 
 ### Part 3
@@ -222,7 +226,6 @@ See [part3/](part3/) for details.
 **NOTE**: We don't support using numbers in definitions, yet.  That will come in part4!
 
 
-
 ### Part 4
 
 Part four allows the user to define their own words, including the use of numbers, from within the REPL.  Here the magic is handling the input of numbers when in "compiling mode".
@@ -240,7 +243,6 @@ To support this we switched our `Words` array from `int` to `float64`, specifica
      ^D
 
 See [part4/](part4/) for details.
-
 
 
 ### Part 5
@@ -292,7 +294,6 @@ So to write out numbers you could try something like this, using `dup` to duplic
      0123456789>
 
 See [part5/](part5/) for details.
-
 
 
 ### Part 6
@@ -371,6 +372,29 @@ I found this page useful, it also documents `invert` which I added for completen
 * https://www.forth.com/starting-forth/4-conditional-if-then-statements/
 
 
+### Part 7
+
+This update adds a basic level of support for strings.
+
+* When a string is encountered it is stored in "memory".
+* The address of the string is pushed to the stack.
+* Two new words are added:
+  * `strlen` show the length of the string at the given address.
+  * `strprn` print the string at the given address.
+
+Sample usage:
+
+    cd part7
+    go build .
+    ./part7
+    > : steve "steve" ;
+    > steve strlen .
+    5
+    > steve strprn .
+    steve
+    ^D
+
+See [part7/](part7/) for the code.
 
 
 ### Final Revision
@@ -416,6 +440,7 @@ See [foth/](foth/) for the implementation.
 
 A brief list of known-issues:
 
+
 ### Loops
 
 The handling of loops isn't correct when there should be zero-iterations:
@@ -439,6 +464,7 @@ value before we proceed, only running the loop if the value is non-zero.
 
 
 
+
 # See Also
 
 This repository was put together after [experimenting with a scripting language](https://github.com/skx/monkey/), an [evaluation engine](https://github.com/skx/evalfilter/), putting together a [TCL-like scripting language](https://github.com/skx/critical), writing a [BASIC interpreter](https://github.com/skx/gobasic) and creating [yet another lisp](https://github.com/skx/yal).
@@ -449,6 +475,7 @@ I've also played around with a couple of compilers which might be interesting to
   * [https://github.com/skx/bfcc/](https://github.com/skx/bfcc/)
 * A math-compiler:
   * [https://github.com/skx/math-compiler](https://github.com/skx/math-compiler)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -376,9 +376,11 @@ I found this page useful, it also documents `invert` which I added for completen
 
 This update adds a basic level of support for strings.
 
-* When a string is encountered it is stored in "memory".
-* The address of the string is pushed to the stack.
-* Two new words are added:
+* When we see a string we store it in an array of strings.
+* We then push the offset of the new string entry onto the stack.
+* This allows it to be referenced and used.
+* Three new words are added:
+  * `strings` Return the number of strings we've seen/stored.
   * `strlen` show the length of the string at the given address.
   * `strprn` print the string at the given address.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The end-result of this work is a simple scripting-language which you could easil
 * Support for printing the top-most stack element (`.`, or `print`).
 * Support for outputting ASCII characters (`emit`).
 * Support for outputting strings (`." Hello, World "`).
+  * Some additional string-support for counting lengths, etc.
 * Support for basic stack operations (`clearstack`, `drop`, `dup`, `over`, `swap`, `.s`)
 * Support for loops, via `do`/`loop`.
 * Support for conditional-execution, via `if`, `else`, and `then`.
@@ -80,7 +81,7 @@ You can find binary releases of the final-version upon the [project release page
 Either run this to download and install the binary:
 
 ```
-$ go get github.com/skx/foth/foth@v0.4.0
+$ go get github.com/skx/foth/foth@v0.5.0
 
 ```
 
@@ -110,7 +111,7 @@ This embeds the interpreter within an application, and defines some new words to
 
 ## Anti-Features
 
-The obvious omission from this implementation is support for strings in the general case (string support is limited to outputting a constant-string).
+The obvious omission from this implementation is support for strings in the general case (string support is pretty limited to calling strlen, and printing strings which are constant and "inline").
 
 We also lack the meta-programming facilities that FORTH users would expect, in a FORTH system it is possible to implement new control-flow systems, for example, by working with words and the control-flow directly.  Instead in this system these things are unavailable, and the implementation of IF/DO/LOOP/ELSE/THEN are handled in the golang-code in a way users cannot modify.
 
@@ -137,7 +138,8 @@ If **you** wanted to extend things further then there are some obvious things to
 
 * Adding more of the "standard" FORTH-words.
   * For example we're missing `pow`, etc.
-* Simplify the special-case handling of string-support.
+* Enhanced the string-support, to allow an input/read from the user, and other primitives.
+  * strcat, strstr, and similar C-like operations would be useful.
 * Simplify the conditional/loop handling.
   * Both of these probably involve using a proper return-stack.
   * This would have the side-effect of allowing new control-flow primitives to be added.

--- a/foth/eval/builtins.go
+++ b/foth/eval/builtins.go
@@ -290,6 +290,50 @@ func (e *Eval) startDefinition() error {
 	return nil
 }
 
+// strings
+func (e *Eval) stringCount() error {
+	// Return the number of strings we've seen
+	e.Stack.Push(float64(len(e.strings)))
+	return nil
+}
+
+// strlen
+func (e *Eval) strlen() error {
+	addr, err := e.Stack.Pop()
+	if err != nil {
+		return err
+	}
+
+	i := int(addr)
+
+	if i < len(e.strings) {
+		str := e.strings[i]
+		e.Stack.Push(float64(len(str)))
+		return nil
+	}
+
+	return fmt.Errorf("invalid stack offset for string reference")
+
+}
+
+// strprn - string printing
+func (e *Eval) strprn() error {
+	addr, err := e.Stack.Pop()
+	if err != nil {
+		return err
+	}
+
+	i := int(addr)
+
+	if i < len(e.strings) {
+		str := e.strings[i]
+		fmt.Printf("%s", str)
+		return nil
+	}
+
+	return fmt.Errorf("invalid stack offset for string reference")
+}
+
 func (e *Eval) sub() error {
 	return e.binOp(func(n float64, m float64) float64 { return m - n })()
 }

--- a/foth/eval/builtins_test.go
+++ b/foth/eval/builtins_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"os"
 	"testing"
 )
 
@@ -734,6 +735,113 @@ func TestSetVar(t *testing.T) {
 		t.Fatalf("value mismatch after setting variable")
 	}
 
+}
+
+// strings counts the string literals, and will return
+// a number on the stack
+func TestStrings(t *testing.T) {
+
+	e := New()
+
+	// Empty stack on first start
+	n := e.Stack.Len()
+	if n != 0 {
+		t.Fatalf("failing result for stringCount, got %d", n)
+	}
+
+	// call the function
+	err := e.stringCount()
+	if err != nil {
+		t.Fatalf("unexpected error with stringCount %s", err.Error())
+	}
+
+	n = e.Stack.Len()
+	if n != 1 {
+		t.Fatalf("failing result for stringCount, got %d", n)
+		os.Exit(1)
+	}
+}
+
+func TestStrlen(t *testing.T) {
+
+	e := New()
+	e.strings = append(e.strings, "Steve")
+
+	// call the function
+	err := e.strlen()
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	// Empty stack on first start
+	n := e.Stack.Len()
+	if n != 0 {
+		t.Fatalf("failing result for strlen, got %d", n)
+	}
+
+	// push an invalid string
+	e.Stack.Push(100.0)
+
+	// call the function
+	err = e.strlen()
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	// Now try to get the length of Steve
+	e.Stack.Push(0.0)
+	err = e.strlen()
+	if err != nil {
+		t.Fatalf("unexpected error, calling strlen %s", err.Error())
+	}
+
+	// Is the result expected?
+	x, _ := e.Stack.Pop()
+	if x != 5 {
+		t.Fatalf("wrong result for strlen, got %f", x)
+	}
+}
+
+func TestStrPrn(t *testing.T) {
+
+	e := New()
+
+	// We want to avoid spamming stdout, so our string to print is "empty"
+	e.strings = append(e.strings, "")
+
+	// call the function
+	err := e.strprn()
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	// Empty stack on first start
+	n := e.Stack.Len()
+	if n != 0 {
+		t.Fatalf("failing result for strprn, got %d", n)
+	}
+
+	// push an invalid string
+	e.Stack.Push(100.0)
+
+	// call the function
+	err = e.strprn()
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	// Now try to get the length of Steve
+	e.Stack.Push(0.0)
+	err = e.strprn()
+	if err != nil {
+		t.Fatalf("unexpected error, calling strprn %s", err.Error())
+	}
+
+	// Empty stack, still?
+	n = e.Stack.Len()
+	if n != 0 {
+		t.Fatalf("failing result for strprn, got %d", n)
+	}
 }
 
 func TestSub(t *testing.T) {

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -210,6 +210,11 @@ func New() *Eval {
 		{Name: ";", Function: e.nop},
 		{Name: "dump", Function: e.dump},
 		{Name: "words", Function: e.words},
+
+		// strings
+		{Name: "strings", Function: e.stringCount},
+		{Name: "strlen", Function: e.strlen},
+		{Name: "strprn", Function: e.strprn},
 	}
 
 	return e
@@ -312,6 +317,13 @@ func (e *Eval) Eval(input string) error {
 			idx = e.findVariable(tok)
 			if idx >= 0 {
 				e.Stack.Push(float64(idx))
+				continue
+			}
+
+			// String
+			if token.Name == "\"" {
+				e.strings = append(e.strings, token.Value)
+				e.Stack.Push(float64(len(e.strings) - 1))
 				continue
 			}
 
@@ -661,6 +673,14 @@ func (e *Eval) compileToken(token lexer.Token) error {
 		// the offset of the variable onto the stack
 		e.tmp.Words = append(e.tmp.Words, -1)
 		e.tmp.Words = append(e.tmp.Words, float64(idx))
+		return nil
+	}
+
+	// save a string, in compiled form
+	if token.Name == "\"" {
+		e.strings = append(e.strings, token.Value)
+		e.tmp.Words = append(e.tmp.Words, -1)
+		e.tmp.Words = append(e.tmp.Words, float64(len(e.strings))-1)
 		return nil
 	}
 

--- a/foth/eval/eval.go
+++ b/foth/eval/eval.go
@@ -543,7 +543,7 @@ func (e *Eval) compileToken(token lexer.Token) error {
 
 		}
 
-		// output a string, in compiled form
+		// output a string-print operation, in compiled form
 		if token.Name == ".\"" {
 			e.strings = append(e.strings, token.Value)
 			e.tmp.Words = append(e.tmp.Words, -5)

--- a/foth/lexer/lexer.go
+++ b/foth/lexer/lexer.go
@@ -110,6 +110,36 @@ func (l *Lexer) Tokens() ([]Token, error) {
 				return res, fmt.Errorf("unterminated comment")
 			}
 
+			// This is for strings
+		case "\"":
+
+			// skip the opening """
+			offset++
+
+			// We're now inside the string
+			closed := false
+			val := ""
+			for offset < len(l.input) {
+				if l.input[offset] == '"' {
+					closed = true
+					offset++
+					break
+				} else {
+					val += string(l.input[offset])
+				}
+				offset++
+			}
+
+			// Failed to close the string?
+			if !closed {
+				return res, fmt.Errorf("unterminated string")
+			}
+
+			// Otherwise save it away
+			val = strings.TrimSpace(val)
+			res = append(res, Token{Name: "\"", Value: val})
+
+			// This is for ." xxx "
 		case ".":
 
 			// ensure we don't walk off the array

--- a/foth/lexer/lexer.go
+++ b/foth/lexer/lexer.go
@@ -120,13 +120,48 @@ func (l *Lexer) Tokens() ([]Token, error) {
 			closed := false
 			val := ""
 			for offset < len(l.input) {
-				if l.input[offset] == '"' {
+				c := l.input[offset]
+
+				if c == '"' {
 					closed = true
 					offset++
 					break
-				} else {
-					val += string(l.input[offset])
 				}
+
+				// Handle \n, etc.
+				if c == '\\' {
+
+					// if there is another character
+					if offset+1 < len(l.input) {
+
+						// look at what it is
+						offset++
+						c := l.input[offset]
+
+						if c == 'n' {
+							c = '\n'
+						}
+						if c == 'r' {
+							c = '\r'
+						}
+						if c == 't' {
+							c = '\t'
+						}
+						if c == '"' {
+							c = '"'
+						}
+						if c == '\\' {
+							c = '\\'
+						}
+
+						val += string(c)
+						offset++
+						continue
+					}
+				}
+
+				// default
+				val += string(l.input[offset])
 				offset++
 			}
 

--- a/foth/lexer/lexer_test.go
+++ b/foth/lexer/lexer_test.go
@@ -134,10 +134,48 @@ func TestString(t *testing.T) {
 
 }
 
+func TestString2(t *testing.T) {
+
+	l := New("start \" foo bar baz \" end")
+	out, err := l.Tokens()
+
+	if err != nil {
+		t.Fatalf("error lexing")
+	}
+
+	if out[0].Name != "start" {
+		t.Fatalf("got bad prefix")
+	}
+	if out[1].Name != "\"" {
+		t.Fatalf("got bad string")
+	}
+	if out[1].Value != "foo bar baz" {
+		t.Fatalf("got bad string: '%s'", out[1].Value)
+	}
+	if out[2].Name != "end" {
+		t.Fatalf("got bad suffix")
+	}
+
+}
+
 // Unterminated strings are a bug
 func TestStringUnterminated(t *testing.T) {
 
 	l := New("  .\" string here ")
+
+	_, err := l.Tokens()
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "unterminated string") {
+		t.Fatalf("got an error, but the wrong one")
+	}
+}
+
+// Unterminated strings are a bug
+func TestStringUnterminated2(t *testing.T) {
+
+	l := New("  \" string here ")
 
 	_, err := l.Tokens()
 	if err == nil {

--- a/foth/lexer/lexer_test.go
+++ b/foth/lexer/lexer_test.go
@@ -82,6 +82,22 @@ func TestCommentNested(t *testing.T) {
 	}
 }
 
+// Escape characters
+func TestEscapeCharacters(t *testing.T) {
+
+	l := New("\"hello\n\r\t\r\\\"\\\\steve\"")
+
+	toks, err := l.Tokens()
+	if err != nil {
+		t.Fatalf("unexpected error %s", err.Error())
+	}
+
+	expect := "hello\n\r\t\r\"\\steve"
+	if toks[0].Value != expect {
+		t.Fatalf("unexpected value for string; got '%s' not '%s'", toks[0].Value, expect)
+	}
+}
+
 // Unterminated comments are a bug
 func TestCommentUnterminated(t *testing.T) {
 

--- a/foth/lexer/lexer_test.go
+++ b/foth/lexer/lexer_test.go
@@ -85,7 +85,7 @@ func TestCommentNested(t *testing.T) {
 // Escape characters
 func TestEscapeCharacters(t *testing.T) {
 
-	l := New("\"hello\n\r\t\r\\\"\\\\steve\"")
+	l := New("\"hello\\n\\r\\t\\r\\\"\\\\steve\"")
 
 	toks, err := l.Tokens()
 	if err != nil {

--- a/part7/README.md
+++ b/part7/README.md
@@ -4,11 +4,11 @@ Part seven of the implementation is very similar to [part6](../part6/), the diff
 
 The specific problem we have is that our stack, and word definitions, only allow support for storing floating-point numbers.  So we cannot store a string on the stack, which means we must be indirect:
 
-* When we see a string we store it in an array of strings.
+* When we see a string we store it in an array of known strings.
 * We then push the offset of the new string entry onto the stack.
 * This allows it to be referenced and used.
 
-However because we don't have arbitrary read/write to RAM opcodes/words we can't do much more than that.  We've added two new string-specific words as a proof of concept though:
+However because we don't have arbitrary read/write to RAM opcodes/words we can't do much more than that.  We've added some new string-specific words as a proof of concept though:
 
 * `strlen` - Return the length of a string.
 * `strprn` - Print a string.
@@ -28,6 +28,9 @@ go build .
 5
 > steve strprn .
 steve
+> "test" strlen .
+4
+>
 ^D
 ```
 
@@ -35,9 +38,7 @@ steve
 
 ## Implementation
 
-The implementation here is pretty simple again, as suits a tutorial-code.
-
-The interpreter got a new string-storing area:
+The implementation here is pretty simple again, as suits tutorial-code.  The interpreter already had a string-storing area, added for the string-literal printing support:
 
 ```
 // Eval is our evaluation structure
@@ -55,6 +56,7 @@ In the past when we saw input we didn't recognize we assumed it was a number, an
 * Append the string to our storage array.
 * Push the offset of the new entry.
   * Using the magic -1 value, if we're in compiling mode.
+  * If you recall from [part4](../part4/) this is the magic word that allows a number to be read from the word's definition.
 
 From there there is no special support.  The primitives just read from the string area, for example `strlen` looks like this:
 
@@ -77,4 +79,4 @@ func (e *Eval) strlen() {
 
 ## Bugs
 
-Because we don't have a decent lexer we can only handle strings without spaces, or newlines.
+Because we don't have a decent lexer we can only handle strings without spaces, or newlines.  Our [final version](../foth/) corrects that problem, and adds support for `\t`, `\n`, etc.

--- a/part7/README.md
+++ b/part7/README.md
@@ -1,0 +1,80 @@
+# Part 7
+
+Part seven of the implementation is very similar to [part6](../part6/), the difference is that we've added **basic** support for strings.
+
+The specific problem we have is that our stack, and word definitions, only allow support for storing floating-point numbers.  So we cannot store a string on the stack, which means we must be indirect:
+
+* When we see a string we store it in an array of strings.
+* We then push the offset of the new string entry onto the stack.
+* This allows it to be referenced and used.
+
+However because we don't have arbitrary read/write to RAM opcodes/words we can't do much more than that.  We've added two new string-specific words as a proof of concept though:
+
+* `strlen` - Return the length of a string.
+* `strprn` - Print a string.
+* `strings` - Return the maximum string index we've seen.
+
+
+
+## Building
+
+To build and run this version:
+
+```
+go build .
+./part7
+> : steve "steve" ;
+> steve strlen .
+5
+> steve strprn .
+steve
+^D
+```
+
+
+
+## Implementation
+
+The implementation here is pretty simple again, as suits a tutorial-code.
+
+The interpreter got a new string-storing area:
+
+```
+// Eval is our evaluation structure
+type Eval struct {
+
+..
+	// strings contains string-storage
+	strings []string
+}
+```
+
+In the past when we saw input we didn't recognize we assumed it was a number, and parsed that with `strconv.ParseFloat`, but now we test if the first character of the token is a `"` character.  If it is we :
+
+* Strip the leading/trailing `"` from it.
+* Append the string to our storage array.
+* Push the offset of the new entry.
+  * Using the magic -1 value, if we're in compiling mode.
+
+From there there is no special support.  The primitives just read from the string area, for example `strlen` looks like this:
+
+```
+// strlen
+func (e *Eval) strlen() {
+	addr := e.Stack.Pop()
+	i := int(addr)
+
+	if i < len(e.strings) {
+		str := e.strings[i]
+		e.Stack.Push(float64(len(str)))
+	} else {
+		e.Stack.Push(-1)
+	}
+}
+```
+
+
+
+## Bugs
+
+Because we don't have a decent lexer we can only handle strings without spaces, or newlines.

--- a/part7/builtins.go
+++ b/part7/builtins.go
@@ -1,0 +1,213 @@
+// This file contains the built-in facilities we have hard-coded.
+//
+// That means the implementation for "+", "-", "/", "*", and "print".
+//
+// We've added `emit` here, to output the value at the top of the stack
+// as an ASCII character, as well as "do" (nop) and "loop".
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (e *Eval) add() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	e.Stack.Push(a + b)
+}
+
+func (e *Eval) div() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	e.Stack.Push(b / a)
+}
+
+func (e *Eval) do() {
+	// nop
+}
+
+func (e *Eval) drop() {
+	e.Stack.Pop()
+}
+
+func (e *Eval) dup() {
+	a := e.Stack.Pop()
+	e.Stack.Push(a)
+	e.Stack.Push(a)
+}
+
+func (e *Eval) emit() {
+	a := e.Stack.Pop()
+	fmt.Printf("%c", rune(a))
+}
+
+func (e *Eval) eq() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	if a == b {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) gt() {
+	b := e.Stack.Pop()
+	a := e.Stack.Pop()
+	if a > b {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) gtEq() {
+	b := e.Stack.Pop()
+	a := e.Stack.Pop()
+	if a >= b {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) iff() {
+	// nop
+}
+
+func (e *Eval) invert() {
+	v := e.Stack.Pop()
+	if v == 0 {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) loop() {
+	cur := e.Stack.Pop()
+	max := e.Stack.Pop()
+
+	cur++
+
+	e.Stack.Push(max)
+	e.Stack.Push(cur)
+}
+
+func (e *Eval) lt() {
+	b := e.Stack.Pop()
+	a := e.Stack.Pop()
+	if a < b {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) ltEq() {
+	b := e.Stack.Pop()
+	a := e.Stack.Pop()
+	if a <= b {
+		e.Stack.Push(1)
+	} else {
+		e.Stack.Push(0)
+	}
+}
+
+func (e *Eval) mul() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	e.Stack.Push(a * b)
+}
+
+func (e *Eval) print() {
+	a := e.Stack.Pop()
+
+	// If the value on the top of the stack is an integer
+	// then show it as one - i.e. without any ".00000".
+	if float64(int(a)) == a {
+		fmt.Printf("%d\n", int(a))
+		return
+	}
+
+	// OK we have a floating-point result.  Show it, but
+	// remove any trailing "0".
+	//
+	// This means we get 1.25 instead of 1.2500000 shown
+	// when the user runs `5 4 / .`.
+	//
+	output := fmt.Sprintf("%f", a)
+	for strings.HasSuffix(output, "0") {
+		output = strings.TrimSuffix(output, "0")
+	}
+	fmt.Printf("%s\n", output)
+
+}
+
+// startDefinition moves us into compiling-mode
+//
+// Note the interpreter handles removing this when it sees ";"
+func (e *Eval) startDefinition() {
+	e.compiling = true
+}
+
+// strings
+func (e *Eval) stringCount() {
+	// Return the number of strings we've seen
+	e.Stack.Push(float64(len(e.strings)))
+}
+
+// strlen
+func (e *Eval) strlen() {
+	addr := e.Stack.Pop()
+	i := int(addr)
+
+	if i < len(e.strings) {
+		str := e.strings[i]
+		e.Stack.Push(float64(len(str)))
+	} else {
+		e.Stack.Push(-1)
+	}
+}
+
+// strprn - string printing
+func (e *Eval) strprn() {
+	addr := e.Stack.Pop()
+	i := int(addr)
+
+	if i < len(e.strings) {
+		str := e.strings[i]
+		fmt.Printf("%s", str)
+	}
+}
+
+func (e *Eval) sub() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	e.Stack.Push(b - a)
+}
+
+func (e *Eval) swap() {
+	a := e.Stack.Pop()
+	b := e.Stack.Pop()
+	e.Stack.Push(a)
+	e.Stack.Push(b)
+}
+
+func (e *Eval) then() {
+	// nop
+}
+
+func (e *Eval) words() {
+	known := []string{}
+
+	for _, entry := range e.Dictionary {
+		known = append(known, entry.Name)
+	}
+
+	sort.Strings(known)
+	fmt.Printf("%s\n", strings.Join(known, " "))
+}

--- a/part7/eval.go
+++ b/part7/eval.go
@@ -1,0 +1,383 @@
+// part6 - allow if, and implement more built-ins to make that useful.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Word is the structure for a single word
+type Word struct {
+	// Name is the name of the function "+", "print", etc.
+	Name string
+
+	// Function is the function-pointer to call to invoke it.
+	//
+	// If this is nil then instead we interpret the known-codes
+	// from previously defined words.
+	Function func()
+
+	// Words holds the words we execute if the function-pointer
+	// is empty.
+	//
+	// The indexes here are relative to the Dictionary our evaluator
+	// holds/maintains
+	Words []float64
+}
+
+// Eval is our evaluation structure
+type Eval struct {
+
+	// Internal stack
+	Stack Stack
+
+	// Dictionary entries
+	Dictionary []Word
+
+	// Are we in a compiling mode?
+	compiling bool
+
+	// Temporary word we're compiling
+	tmp Word
+
+	// open of the last do
+	doOpen int
+
+	// offset of the argument to any IF
+	ifOffset int
+
+	// strings contains string-storage
+	strings []string
+}
+
+// NewEval returns a simple evaluator
+func NewEval() *Eval {
+
+	// Empty structure
+	e := &Eval{}
+
+	// Populate the dictionary of words we have implemented
+	// which are hard-coded.
+	e.Dictionary = []Word{
+		{Name: "*", Function: e.mul},
+		{Name: "+", Function: e.add},
+		{Name: "-", Function: e.sub},
+		{Name: ".", Function: e.print},
+		{Name: "/", Function: e.div},
+		{Name: ":", Function: e.startDefinition},
+		{Name: "<", Function: e.lt},
+		{Name: "<=", Function: e.ltEq},
+		{Name: "=", Function: e.eq},
+		{Name: "==", Function: e.eq},
+		{Name: ">", Function: e.gt},
+		{Name: ">=", Function: e.gtEq},
+		{Name: "do", Function: e.do},  // NOP
+		{Name: "if", Function: e.iff}, // NOP
+		{Name: "invert", Function: e.invert},
+		{Name: "drop", Function: e.drop},
+		{Name: "dup", Function: e.dup},
+		{Name: "emit", Function: e.emit},
+		{Name: "loop", Function: e.loop},
+		{Name: "print", Function: e.print},
+		{Name: "swap", Function: e.swap},
+		{Name: "then", Function: e.then}, // NOP
+		{Name: "words", Function: e.words},
+		{Name: "strings", Function: e.stringCount},
+		{Name: "strlen", Function: e.strlen},
+		{Name: "strprn", Function: e.strprn},
+	}
+
+	return e
+}
+
+// Eval processes a list of tokens.
+//
+// This is invoked by our repl with a line of input at the time.
+func (e *Eval) Eval(args []string) {
+
+	for _, tok := range args {
+
+		// Trim the leading/trailing spaces,
+		// and skip any empty tokens
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+
+		// Are we in compiling mode?
+		if e.compiling {
+
+			// If we don't have a name
+			if e.tmp.Name == "" {
+
+				// is the name used?
+				idx := e.findWord(tok)
+				if idx != -1 {
+					fmt.Printf("word %s already defined\n", tok)
+					os.Exit(1)
+				}
+
+				// save the name
+				e.tmp.Name = tok
+
+				continue
+			}
+
+			// End of a definition?
+			if tok == ";" {
+				e.Dictionary = append(e.Dictionary, e.tmp)
+
+				e.tmp.Name = ""
+				e.tmp.Words = []float64{}
+				e.compiling = false
+
+				continue
+
+			}
+
+			// OK we have a name, so lookup the word definition
+			// for it.
+			idx := e.findWord(tok)
+			if idx >= 0 {
+				// Found it
+				e.tmp.Words = append(e.tmp.Words, float64(idx))
+
+				// If the word was a "DO"
+				if tok == "do" {
+					e.doOpen = len(e.tmp.Words) - 1
+				}
+
+				// if the word was a "LOOP"
+				if tok == "loop" {
+
+					// offset of do must be present
+					e.tmp.Words = append(e.tmp.Words, -2)
+					e.tmp.Words = append(e.tmp.Words, float64(e.doOpen))
+				}
+
+				// If the word was a "if"
+				if tok == "if" {
+					// we add the conditional-jump opcode
+					e.tmp.Words = append(e.tmp.Words, -3)
+					// placeholder jump-offset
+					e.tmp.Words = append(e.tmp.Words, 99)
+
+					// save the address of our stub,
+					// so we can back-patch
+					e.ifOffset = len(e.tmp.Words)
+				}
+
+				if tok == "then" {
+					// back - patch the jump offset to the position of this word
+					e.tmp.Words[e.ifOffset-1] = float64(len(e.tmp.Words) - 1)
+				}
+
+			} else {
+
+				// If this starts with a " then it is a strings
+				// Append it, and push the offset
+				if len(tok) > 0 && tok[0] == '"' {
+
+					// Remove leading/trailing "
+					str := tok
+					str = str[1:]
+					str = str[:(len(str) - 1)]
+
+					// Append the string and get its offset
+					e.strings = append(e.strings, str)
+
+					offset := len(e.strings) - 1
+
+					// We're pushing an int, which is the offset of the string
+					e.tmp.Words = append(e.tmp.Words, -1)
+					e.tmp.Words = append(e.tmp.Words, float64(offset))
+					continue
+				}
+
+				// OK we assume the user entered a number
+				// so we save a magic "-1" flag in our
+				// definition, and then the number itself
+				e.tmp.Words = append(e.tmp.Words, -1)
+
+				// Convert to float
+				val, err := strconv.ParseFloat(tok, 64)
+				if err != nil {
+					fmt.Printf("%s: %s\n", tok, err.Error())
+					return
+				}
+				e.tmp.Words = append(e.tmp.Words, val)
+			}
+
+			continue
+		}
+
+		// Did we handle this as a dictionary item?
+		handled := false
+		for index, word := range e.Dictionary {
+			if tok == word.Name {
+				e.evalWord(index)
+				handled = true
+			}
+		}
+
+		// If we didn't handle this as a word, then
+		// assume it is a number.
+		if !handled {
+
+			// If this starts with a " then it is a strings
+			// Append it, and push the offset
+			if len(tok) > 0 && tok[0] == '"' {
+
+				// Remove leading/trailing "
+				str := tok
+				str = str[1:]
+				str = str[:(len(str) - 1)]
+				e.strings = append(e.strings, str)
+				e.Stack.Push(float64(len(e.strings) - 1))
+				continue
+			}
+
+			i, err := strconv.ParseFloat(tok, 64)
+			if err != nil {
+				fmt.Printf("%s: %s\n", tok, err.Error())
+				return
+			}
+
+			e.Stack.Push(i)
+		}
+	}
+}
+
+// evalWord evaluates a word, by index from the dictionary
+//
+// * Functions might contain a pointer to a function implemented in go.
+//
+//		If so we just call that pointer.
+//
+//	  - Functions will otherwise have lists of numbers, which point to
+//	    previously defined words.
+//
+//	    In addition to the pointers to previously-defined words there are
+//	    also some special values:
+//
+//	    "-1" means the next value is a number
+//
+//	    "-2" is an unconditional jump, which will change our IP.
+//
+//	    "-3" is a conditional-jump, which will change our IP if
+//	    the topmost item on the stack is "0".
+func (e *Eval) evalWord(index int) {
+
+	// Lookup the word
+	word := e.Dictionary[index]
+
+	// Is this implemented in golang?  If so just invoke the function
+	// and we're done.
+	if word.Function != nil {
+		word.Function()
+		return
+	}
+
+	//
+	// TODO: Improve the way these special cases are handled.
+	//
+	// The reason this is handled like this, is to avoid poking the
+	// indexes directly and risking array-overflow on malformed
+	// word-lists.
+	//
+	// (i.e. When we see "[1, 2, -1]" the last instruction should add
+	// the following number to the stack - but it is missing.  We want
+	// to avoid messing around with the index to avoid that.)
+	//
+
+	// Adding a number?
+	addNum := false
+
+	// jumping?
+	jump := false
+
+	// jumping if the stack has a false-value?
+	condJump := false
+
+	// We need to allow control-jumps now, so we
+	// have to store our index manually.
+	ip := 0
+	for ip < len(word.Words) {
+
+		// the current opcode
+		opcode := word.Words[ip]
+
+		// adding a number?
+		if addNum {
+			// add to stack
+			e.Stack.Push(opcode)
+			addNum = false
+		} else if jump {
+			// If the two top-most entries
+			// are not equal, then jump
+			cur := e.Stack.Pop()
+			max := e.Stack.Pop()
+
+			if max > cur {
+				// put them back
+				e.Stack.Push(max)
+				e.Stack.Push(cur)
+
+				// change opcode
+				ip = int(opcode)
+
+				// decrement as it'll get bumped at
+				// the foot of the loop
+				ip--
+			}
+
+			jump = false
+		} else if condJump {
+			// Jump only if 0 is on the top of the stack.
+			//
+			// i.e. This is an "if" test.
+			val := e.Stack.Pop()
+			if val == 0 {
+				// change opcode
+				ip = int(opcode)
+				// decrement as it'll get bumped at
+				// the foot of the loop
+				ip--
+			}
+			condJump = false
+		} else {
+
+			// if we see -1 we're adding a number
+			if opcode == -1 {
+				addNum = true
+			} else if opcode == -2 {
+				// -2 is a jump
+				jump = true
+			} else if opcode == -3 {
+				// -3 is a conditional-jump
+				condJump = true
+			} else {
+
+				// otherwise we evaluate
+				// otherwise eval as usual
+				e.evalWord(int(opcode))
+			}
+		}
+
+		// next instruction
+		ip++
+	}
+}
+
+// findWords returns the index in our dictionary of the entry for the
+// given-name.  Returns -1 if the word cannot be found.
+func (e *Eval) findWord(name string) int {
+	for index, word := range e.Dictionary {
+		if name == word.Name {
+			return index
+		}
+	}
+	return -1
+}

--- a/part7/foth.4th
+++ b/part7/foth.4th
@@ -1,0 +1,51 @@
+#
+# This file is loaded on-startup, if it is present.
+#
+# NOTE: Lines having a "#"-prefix will be skipped.
+#
+#       This is not a standard approach to FORTH comments, but it makes
+#       sense for this particular implementation.
+#
+
+
+#
+# CR: Output a carrige return (newline).
+#
+: cr 10 emit ;
+
+#
+# Star: Output a star to the console.
+#
+# Here 42 is the ASCII code for the "*" character.
+#
+: star 42 emit ;
+
+
+#
+# Stars: Show the specified number of stars.
+#
+#        e.g. "3 stars"
+#
+: stars 0 do star loop 10 emit ;
+
+
+#
+# square: Square a number
+#
+: square dup * ;
+
+#
+# cube: cube a number
+#
+: cube dup square * ;
+
+#
+# 1+: add one to a number
+#
+: 1+ 1 + ;
+
+#
+# boot: output a message on-startup
+#
+: bootup 87 emit 101 emit 108 emit 99 emit 111 emit 109 emit 101 emit 32 emit 116 emit 111 emit 32 emit 102 emit 111 emit 116 emit 104 emit 33 emit 10 emit ;
+bootup

--- a/part7/main.go
+++ b/part7/main.go
@@ -1,0 +1,67 @@
+// part6 driver
+//
+// Loads "foth.4th" from cwd, if present, and evaluates it before the REPL
+// is launched - otherwise the same as previous versions.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// If the given file exists, read the contents, and evaluate it
+func doInit(eval *Eval, path string) {
+
+	handle, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	reader := bufio.NewReader(handle)
+	line, err := reader.ReadString(byte('\n'))
+	for err == nil {
+
+		// Trim it
+		line = strings.TrimSpace(line)
+
+		// Is this isn't comment then execute it
+		if !strings.HasPrefix(line, "#") {
+
+			// Evaluate
+			eval.Eval(strings.Split(line, " "))
+		}
+
+		// Repeat
+		line, err = reader.ReadString(byte('\n'))
+	}
+
+	handle.Close()
+}
+
+func main() {
+
+	reader := bufio.NewReader(os.Stdin)
+	forth := NewEval()
+
+	// Load the init-file if it is present.
+	doInit(forth, "foth.4th")
+
+	for {
+		fmt.Printf("> ")
+
+		// Read input
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("error reading input: %s\n", err.Error())
+			return
+		}
+
+		// Trim it
+		text = strings.TrimSpace(text)
+
+		forth.Eval(strings.Split(text, " "))
+	}
+}

--- a/part7/stack.go
+++ b/part7/stack.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// Stack holds our numbers.
+type Stack []float64
+
+// IsEmpty checks if our stack is empty.
+func (s *Stack) IsEmpty() bool {
+	return len(*s) == 0
+}
+
+// Push adds a new number to the stack
+func (s *Stack) Push(x float64) {
+	*s = append(*s, x)
+}
+
+// Pop removes and returns the top element of stack.
+func (s *Stack) Pop() float64 {
+	if s.IsEmpty() {
+		fmt.Printf("stack underflow\n")
+		os.Exit(1)
+	}
+
+	i := len(*s) - 1
+	x := (*s)[i]
+	*s = (*s)[:i]
+
+	return x
+}


### PR DESCRIPTION
This is pretty simple to implement, and understand.

* part7 is linked to in the main README
  * It allows string-support, providing whitespace isn't used.
  * New primitives added `strings`, `strlen`, and `strprn`.

I've also updated the final version, in `foth/`, to add similar support there, with proper whitespace handling.

With more testing this will close #20.